### PR TITLE
Use ygot generator flag for package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,7 +8,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var generatorTemplate = `package {{.PackageName}}
+var generatorTemplate = `
+{{- $package_name := "ocstructs" -}}
+{{range .GeneratorOptions -}}
+    {{ if eq .Option "package_name" -}}
+        {{$package_name = .Value -}}
+        {{break -}}
+    {{end -}}
+{{end -}}
+package {{$package_name}}
 
 // This file is a placeholder in order to ensure that Go does not
 // find this directory to contain an empty package.
@@ -22,7 +30,6 @@ type GeneratorOptions struct {
 }
 
 type Manifest struct {
-	PackageName      string             `yaml:"package_name,omitempty"`
 	PathToGenerator  string             `yaml:"path_to_generator,omitempty"`
 	PathToModels     string             `yaml:"path_to_models,omitempty"`
 	GeneratorOptions []GeneratorOptions `yaml:"generator_options,omitempty"`

--- a/testdata/no-package-name-provided.golden
+++ b/testdata/no-package-name-provided.golden
@@ -1,0 +1,6 @@
+package ocstructs
+
+// This file is a placeholder in order to ensure that Go does not
+// find this directory to contain an empty package.
+
+//go:generate ../../../build-tools/generator -path=../../..models/openconfig  -output_file=./yang.go   ../../../models/openconfig/release/models/local-routing/openconfig-local-routing.yang  ../../../models/openconfig/release/models/system/openconfig-messages.yang 

--- a/testdata/no-package-name-provided.input
+++ b/testdata/no-package-name-provided.input
@@ -1,7 +1,5 @@
 ---
 generator_options:
-  - option: package_name
-    value: openconfig
   - option: output_file
     value: ./yang.go
 models:


### PR DESCRIPTION
This commit enables the naming of the package for the generated file to
be based on the ygot flag provided.

If there is no package name provided, then the default `ocstructs` (see [here](https://github.com/openconfig/ygot/blob/e7b18d306e0883a150758dd89d965a33bd57e49b/generator/generator.go#L67)).